### PR TITLE
Break out of named pipe search to send less packets

### DIFF
--- a/zzz_exploit.py
+++ b/zzz_exploit.py
@@ -293,6 +293,7 @@ def find_named_pipe(conn):
 			fid = conn.nt_create_andx(tid, pipe)
 			conn.close(tid, fid)
 			found_pipe = pipe
+			break
 		except smb.SessionError as e:
 			pass
 	


### PR DESCRIPTION
The loop will go on even after a suitable named pipe is found.

Small change just breaks out early, sending a few less packets.